### PR TITLE
Fix multiple environments being load balanced

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -43,11 +43,18 @@ services:
     depends_on:
       - console
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - pm2
+      shared:
+        aliases:
+          - {{ @('namespace') }}_pm2
 networks:
   private:
     external: false
+  monitoring:
+    external:
+      name: my127ws_monitoring
   shared:
     external:
       name: my127ws

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -43,12 +43,8 @@ services:
     depends_on:
       - console
     networks:
-      private:
-        aliases:
-          - pm2
-      shared:
-        aliases:
-          - {{ @('namespace') }}_pm2
+      - private
+      - monitoring
 networks:
   private:
     external: false

--- a/docker/image/console/root/lib/sidekick.sh
+++ b/docker/image/console/root/lib/sidekick.sh
@@ -33,14 +33,14 @@ prompt()
 
 run()
 {
+    local COMMAND="$*"
     if [ "$VERBOSE" = "no" ]; then
         prompt
 
-        echo "  > $*"
+        echo "  > ${COMMAND[*]}"
         setCommandIndicator $INDICATOR_RUNNING
-        bash -c "$@" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
 
-        if [ "$?" != "0" ]; then
+        if ! bash -c "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
             setCommandIndicator $INDICATOR_ERROR
 
             cat /tmp/my127ws-stderr.txt
@@ -55,7 +55,7 @@ run()
             setCommandIndicator $INDICATOR_SUCCESS
         fi
     else
-        passthru "$@"
+        passthru "${COMMAND[@]}"
     fi
 }
 


### PR DESCRIPTION
Traefik talks to `pm2` in the `my127ws` namespace.

If two environments are running at once, the `pm2` DNS address is load balanced between the two environments.

Also use a separate namespace for monitoring.